### PR TITLE
Change function return value to void as it does not return anything, removes warning

### DIFF
--- a/sparsnas_decode.cpp
+++ b/sparsnas_decode.cpp
@@ -213,7 +213,7 @@ public:
   uint32_t bits_;
 };
 
-int run_for_frequencies(FILE *f, FILE *logfile, float F1, float F2) {
+void run_for_frequencies(FILE *f, FILE *logfile, float F1, float F2) {
   uint8_t buf[16384];
   SignalDetector sd;
 


### PR DESCRIPTION
Minor fix for the `run_for_frequencies` function that was declared as int but did not return anything and generated a warning:

> $ g++ -o sparsnas_decode -O3 sparsnas_decode.cpp
> sparsnas_decode.cpp:310:1: warning: control reaches end of non-void function [-Wreturn-type]
> }
> ^
> 1 warning generated.